### PR TITLE
BUGFIX: create config directory if it doesn't exist

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -121,6 +122,16 @@ func getConfigDirPath() (string, error) {
 }
 
 func getConfigFileContents(path string) ([]byte, error) {
+
+	configDir, _ := filepath.Split(path)
+
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		err = os.MkdirAll(configDir, os.ModePerm)
+		if err != nil {
+			return nil, fmt.Errorf("trying to create the config directory \"%s\": %v", configDir, err)
+		}
+	}
+
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		configFile, err := os.Create(path)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -303,6 +303,25 @@ func TestGetConfigFileContentsShouldReturnAExpectedFileContents(t *testing.T) {
 	}
 }
 
+func TestGetConfigFileContentsShouldCreateTheConfigDirectoryIfNotExists(t *testing.T) {
+	// t.Parallel()
+
+	testDir := test.GenerateNewUniqueTestDir(t)
+	defer testDir.CleanTestDir(t)
+
+	testConfigDirectory := testDir.Path + string(os.PathSeparator) + ".sops-age-manager"
+	testConfigFilePath := testConfigDirectory + string(os.PathSeparator) + "config.yaml"
+
+	_, err := getConfigFileContents(testConfigFilePath)
+	if err != nil {
+		t.Fatalf("Error getting config from file: %v", err)
+	}
+
+	if _, err := os.Stat(testConfigDirectory); os.IsNotExist(err) {
+		t.Fatalf("The config directory \"%s\" should exist but does not", testConfigDirectory)
+	}
+}
+
 func TestRawShouldReturnANonEmptyString(t *testing.T) {
 	// t.Parallel()
 


### PR DESCRIPTION
When the default config directory doesn't exists, currently an exception is thrown that it cannot access the directory for file creation, since obviously the directory wasn't created.