### PR TITLE
Add support for multiple commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure to set the active key before using sam,
 if not sops will return an error and sam will return the following error.
 
 ```
-Could not find encryption key ""
+Could not find decryption key ""
 Could not find encryption key ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,20 @@ Could not find encryption key ""
 
 ## Commands
 
-The base command of sam just calls sops with the passed arguments:
+The base command of sam does nothing by itself without a ```--``` separator after which you can 
+execute whatever you want. The base command simply sets the ```SOPS_AGE_KEY``` environment variable to 
+the correct value. For sops commands the ```--age``` argument will be injected automatically to the selected key.
+
+### Examples
 
 ```bash
-sam -- <SOPS_ARGS_HERE>
+sam key use private-helm-manifest
+sam -- sops -d super-secret.enc.yaml
+```
+
+```bash
+sam key use private-helm-manifest
+sam -- sops -e super-secret.dec.yaml
 ```
 
 The ```--age``` argument is passed automatically by sam.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,9 @@ var (
 This wrapper for sops should provide key selection by name, rather than
 by using the private or public key.
 
+Use the base command with '--' after which you can execute what you want. 
+The sops configuration will be applied automatically.
+
 GitHub: https://github.com/SayHeyD/sops-age-manager`,
 		Run: func(cmd *cobra.Command, args []string) {
 			executeSops(args)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,23 +85,21 @@ func executeSops(args []string) {
 
 	if wantedDecryptionKey == nil {
 		log.Printf("Could not find encryption key \"%s\"", appConfig.DecryptionKeyName)
-	} else {
-		args = append([]string{"--age", wantedDecryptionKey.PublicKey}, args...)
 	}
 
-	var sopsOut bytes.Buffer
-	var stderr bytes.Buffer
+	var passThroughOut bytes.Buffer
+	var passThroughErr bytes.Buffer
 
-	sopsCmd := exec.Command("sops", args...)
+	sopsCmd := exec.Command(args[0], args[1:]...)
 
-	sopsCmd.Stdout = &sopsOut
-	sopsCmd.Stderr = &stderr
+	sopsCmd.Stdout = &passThroughOut
+	sopsCmd.Stderr = &passThroughErr
 
 	err = sopsCmd.Run()
 	if err != nil {
-		fmt.Printf("sops error: %v: %s", err, stderr.String())
+		fmt.Printf("sops error: %v: %s", err, passThroughErr.String())
 		return
 	}
 
-	fmt.Print(sopsOut.String())
+	fmt.Print(passThroughOut.String())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,7 +84,7 @@ func executeSops(args []string) {
 	}
 
 	if wantedDecryptionKey == nil {
-		log.Printf("Could not find encryption key \"%s\"", appConfig.DecryptionKeyName)
+		log.Printf("Could not find decryption key \"%s\"", appConfig.DecryptionKeyName)
 	}
 
 	var passThroughOut bytes.Buffer


### PR DESCRIPTION
Currently sam can only be used when executing sops commands. Yet there are f.ex. terraform providers also accessing the ```SOPS_AGE_KEY``` env var. This update allows the execution of whatever command with sam.

When a sops command is detected sam will automatically inject the ```--age``` parameter.