### PR TITLE
root command: check for argument length

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,7 +121,6 @@ func executeSops(args []string) {
 
 		fmt.Print(passThroughOut.String())
 	} else {
-		fmt.Println("No command arguments supplied, exiting")
-		os.Exit(0)
+		log.Fatalf("No command arguments supplied, exiting")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,19 +104,24 @@ func executeSops(args []string) {
 		}
 	}
 
-	var passThroughOut bytes.Buffer
-	var passThroughErr bytes.Buffer
+	if len(args) > 0 {
+		var passThroughOut bytes.Buffer
+		var passThroughErr bytes.Buffer
 
-	sopsCmd := exec.Command(args[0], args[1:]...)
+		sopsCmd := exec.Command(args[0], args[1:]...)
 
-	sopsCmd.Stdout = &passThroughOut
-	sopsCmd.Stderr = &passThroughErr
+		sopsCmd.Stdout = &passThroughOut
+		sopsCmd.Stderr = &passThroughErr
 
-	err = sopsCmd.Run()
-	if err != nil {
-		fmt.Printf("sops error: %v: %s", err, passThroughErr.String())
-		return
+		err = sopsCmd.Run()
+		if err != nil {
+			fmt.Printf("sops error: %v: %s", err, passThroughErr.String())
+			return
+		}
+
+		fmt.Print(passThroughOut.String())
+	} else {
+		fmt.Println("No command arguments supplied, exiting")
+		os.Exit(0)
 	}
-
-	fmt.Print(passThroughOut.String())
 }


### PR DESCRIPTION
Currently there is no check in place if arguments are supplied to the root command. If there are none the program will crash. This PR implements a more graceful shutdown.