### PR TITLE
CI: update lint job PR rules

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/lint.yaml'
 jobs:
   linting:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,10 @@ on:
     paths:
       - '**.go'
       - '.github/workflows/lint.yaml'
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**.go'
+      - '.github/workflows/lint.yaml'
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only run liniting on PRs if changes to go files or the workflow file were made.