### PR TITLE
Ci: update build job and go version

### DIFF
--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -13,7 +13,7 @@ on:
       - beta
 
 env:
-  ARTIFACT_NAME: sam-builds-$GITHUB_SHA
+  ARTIFACT_NAME: sam-builds-${{GITHUB_SHA}}
 
 jobs:
   build-macos-amd64:

--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: my-artifact
+          name: sam-builds-${{ env.GITHUB_SHA }}
           path: bin/*
 
   build-macos-arm64:
@@ -38,7 +38,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: my-artifact
+          name: sam-builds-${{ env.GITHUB_SHA }}
           path: bin/*
 
   build-linux-amd64:
@@ -52,7 +52,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: my-artifact
+          name: sam-builds-${{ env.GITHUB_SHA }}
           path: bin/*
 
   build-linux-arm64:
@@ -66,7 +66,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: my-artifact
+          name: sam-builds-${{ env.GITHUB_SHA }}
           path: bin/*
 
   build-windows-amd64:
@@ -80,7 +80,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: my-artifact
+          name: sam-builds-${{ env.GITHUB_SHA }}
           path: bin/*
 
   build-windows-arm64:
@@ -94,5 +94,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: my-artifact
+          name: sam-builds-${{ env.GITHUB_SHA }}
           path: bin/*

--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -20,82 +20,64 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/workflows/common/go-setup
-      - name: Build macos amd64
-        run: GOARCH=amd64 GOOS=darwin go build -tags main -o bin/sam_darwin_amd64 .
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Build
+        uses: ./.github/workflows/common/go-build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: bin/*
+          GOOS: darwin
+          GOARCH: amd64
+          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
 
   build-macos-arm64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/workflows/common/go-setup
-      - name: Build macos arm64
-        run: GOARCH=arm64 GOOS=darwin go build -tags main -o bin/sam_darwin_arm64 .
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Build
+        uses: ./.github/workflows/common/go-build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: bin/*
+          GOOS: darwin
+          GOARCH: arm64
+          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
 
   build-linux-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/workflows/common/go-setup
-      - name: Build linux amd64
-        run: GOARCH=amd64 GOOS=linux go build -tags main -o bin/sam_linux_amd64 .
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Build
+        uses: ./.github/workflows/common/go-build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: bin/*
+          GOOS: linux
+          GOARCH: amd64
+          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
 
   build-linux-arm64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/workflows/common/go-setup
-      - name: Build linux arm64
-        run: GOARCH=arm64 GOOS=linux go build -tags main -o bin/sam_linux_arm64 .
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Build
+        uses: ./.github/workflows/common/go-build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: bin/*
+          GOOS: darwin
+          GOARCH: arm64
+          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
 
   build-windows-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/workflows/common/go-setup
-      - name: Build windows amd64
-        run: GOARCH=amd64 GOOS=windows go build -tags main -o bin/sam_windows_amd64.exe .
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Build
+        uses: ./.github/workflows/common/go-build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: bin/*
+          GOOS: windows
+          GOARCH: amd64
+          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
 
   build-windows-arm64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/workflows/common/go-setup
-      - name: Build windows arm64
-        run: GOARCH=arm64 GOOS=windows go build -tags main -o bin/sam_windows_arm64.exe .
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Build
+        uses: ./.github/workflows/common/go-build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: bin/*
+          GOOS: darwin
+          GOARCH: arm64
+          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -12,6 +12,9 @@ on:
       - main
       - beta
 
+env:
+  ARTIFACT_NAME: sam-builds-${{ env.GITHUB_SHA }}
+
 jobs:
   build-macos-amd64:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: sam-builds-${{ env.GITHUB_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: bin/*
 
   build-macos-arm64:
@@ -38,7 +41,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: sam-builds-${{ env.GITHUB_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: bin/*
 
   build-linux-amd64:
@@ -52,7 +55,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: sam-builds-${{ env.GITHUB_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: bin/*
 
   build-linux-arm64:
@@ -66,7 +69,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: sam-builds-${{ env.GITHUB_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: bin/*
 
   build-windows-amd64:
@@ -80,7 +83,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: sam-builds-${{ env.GITHUB_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: bin/*
 
   build-windows-arm64:
@@ -94,5 +97,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: sam-builds-${{ env.GITHUB_SHA }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: bin/*

--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -13,7 +13,7 @@ on:
       - beta
 
 env:
-  ARTIFACT_NAME: sam-builds-${{ env.GITHUB_SHA }}
+  ARTIFACT_NAME: sam-builds-$GITHUB_SHA
 
 jobs:
   build-macos-amd64:

--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -13,7 +13,7 @@ on:
       - beta
 
 env:
-  ARTIFACT_NAME: sam-builds-${{GITHUB_SHA}}
+  ARTIFACT_NAME: sam-builds-${{ github.sha }}
 
 jobs:
   build-macos-amd64:

--- a/.github/workflows/build-release-versions.yaml
+++ b/.github/workflows/build-release-versions.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Build
         uses: ./.github/workflows/common/go-build
         with:
-          GOOS: darwin
+          GOOS: linux
           GOARCH: arm64
           ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
 
@@ -78,6 +78,6 @@ jobs:
       - name: Build
         uses: ./.github/workflows/common/go-build
         with:
-          GOOS: darwin
+          GOOS: windows
           GOARCH: arm64
           ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/common/go-build/action.yaml
+++ b/.github/workflows/common/go-build/action.yaml
@@ -1,0 +1,37 @@
+name: "Go build"
+
+description: "Job to build sam for multiple platforms"
+
+inputs:
+  GOARCH:
+    description: 'The CPU architecture for which to build the binaries'
+    default: 'amd64'
+  GOOS:
+    description: 'The Operating system for which to build the binaries'
+    default: 'darwin'
+  ARTIFACT_NAME:
+    description: 'The name of the artifact where the binaries will be uploaded to'
+    default: 'build-versions'
+  ARTIFACT_PATH:
+    description: 'From where the binaries will be uploaded to the artifact'
+    default: 'bin/*'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup
+      uses: ./.github/workflows/common/go-setup
+
+    - name: Build ${{ inputs.GOOS }} ${{ inputs.GOARCH }}
+      run: |
+        GOARCH=${{ inputs.GOARCH }} GOOS=${{ inputs.GOOS }} go build -tags main \
+        -o bin/sam_${{ inputs.GOOS }}_${{ inputs.GOARCH }}$(if [[ ${{ inputs.GOOS }} == "windows" ]]; then echo ".exe") .
+      shell: bash
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.ARTIFACT_NAME }}
+        path: bin/*

--- a/.github/workflows/common/go-build/action.yaml
+++ b/.github/workflows/common/go-build/action.yaml
@@ -27,7 +27,8 @@ runs:
     - name: Build ${{ inputs.GOOS }} ${{ inputs.GOARCH }}
       run: |
         GOARCH=${{ inputs.GOARCH }} GOOS=${{ inputs.GOOS }} go build -tags main \
-        -o bin/sam_${{ inputs.GOOS }}_${{ inputs.GOARCH }}$(if [[ ${{ inputs.GOOS }} == "windows" ]]; then echo ".exe") .
+        -o bin/sam_${{ inputs.GOOS }}_${{ inputs.GOARCH }}$(if [[ "${{ inputs.GOOS }}" == "windows" ]];  \
+        then echo ".exe"; fi) .
       shell: bash
 
     - name: Upload artifact

--- a/.github/workflows/common/go-build/action.yaml
+++ b/.github/workflows/common/go-build/action.yaml
@@ -27,7 +27,7 @@ runs:
     - name: Build ${{ inputs.GOOS }} ${{ inputs.GOARCH }}
       run: |
         GOARCH=${{ inputs.GOARCH }} GOOS=${{ inputs.GOOS }} go build -tags main \
-        -o bin/sam_${{ inputs.GOOS }}_${{ inputs.GOARCH }}$(if [[ "${{ inputs.GOOS }}" == "windows" ]];  \
+        -o bin/sam_${{ inputs.GOOS }}_${{ inputs.GOARCH }}$(if [[ "${{ inputs.GOOS }}" == "windows" ]]; \
         then echo ".exe"; fi) .
       shell: bash
 

--- a/.github/workflows/common/go-build/action.yaml
+++ b/.github/workflows/common/go-build/action.yaml
@@ -24,7 +24,7 @@ runs:
     - name: Setup
       uses: ./.github/workflows/common/go-setup
 
-    - name: Build ${{ inputs.GOOS }} ${{ inputs.GOARCH }}
+    - name: Build
       run: |
         GOARCH=${{ inputs.GOARCH }} GOOS=${{ inputs.GOOS }} go build -tags main \
         -o bin/sam_${{ inputs.GOOS }}_${{ inputs.GOARCH }}$(if [[ "${{ inputs.GOOS }}" == "windows" ]]; \

--- a/.github/workflows/common/go-setup/action.yaml
+++ b/.github/workflows/common/go-setup/action.yaml
@@ -9,7 +9,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: '1.21'
 
     - name: Install dependencies
       run: go get -t ./...


### PR DESCRIPTION
- Update go versions with which to tool is built to 1.21
- Streamlined the build-release-versions job
  - Created custom action with inputs